### PR TITLE
fix: Correct syntax in netlify.toml

### DIFF
--- a/google-sheets-webapp/netlify.toml
+++ b/google-sheets-webapp/netlify.toml
@@ -19,4 +19,3 @@
   from = "/*"
   to = "/index.html"
   status = 200
-EOF


### PR DESCRIPTION
Removes an extraneous EOF marker from the end of the netlify.toml file. This marker was causing a parsing error during Netlify builds. The corrected file should now parse successfully.