### PR TITLE
fix: Update Google Sheet GID in sheetService

### DIFF
--- a/google-sheets-webapp/src/services/sheetService.js
+++ b/google-sheets-webapp/src/services/sheetService.js
@@ -4,7 +4,7 @@ import Papa from 'papaparse';
 // Extracted SHEET_ID: 1Js7j6E1PJ-YSrUmiNKxiAhGGjVACAaUf
 // Extracted GID (from 'sd=true' which implies the first sheet, gid=0): 0
 const SHEET_ID = '1Js7j6E1PJ-YSrUmiNKxiAhGGjVACAaUf';
-const GID = '0'; // Assuming the first sheet as 'sd=true' usually points to the default sheet (gid=0)
+const GID = '517478424'; // Assuming the first sheet as 'sd=true' usually points to the default sheet (gid=0)
 
 const CSV_EXPORT_URL = `https://docs.google.com/spreadsheets/d/${SHEET_ID}/export?format=csv&gid=${GID}`;
 


### PR DESCRIPTION
Changes the GID constant in sheetService.js to '517478424'. This ensures the application fetches data from the correct tab within the specified Google Sheet, as indicated by your provided URL. The previous GID was '0', pointing to the first tab.